### PR TITLE
Bite 1116

### DIFF
--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -16,6 +16,14 @@
         name: "{{namespace}}"
         acl_type: "client"
         rules: "{{rule_read}}"
+      on-success: "stash_read_token"
+    -
+      name: "stash_read_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "consul-{{namespace}}-read"
+        value: "{{create_token_read}}"
+        ns: "{{namespace}}"
       on-success: "create_ns_consul_rule_write"
     -
       name: "create_ns_consul_rule_write"
@@ -33,3 +41,11 @@
         name: "{{namespace}}"
         acl_type: "client"
         rules: "{{rule_write}}"
+      on-success: "stash_write_token"
+    -
+      name: "stash_write_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "consul-{{namespace}}-write"
+        value: "{{create_token_write}}"
+        ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -32,7 +32,7 @@
         namespace: "{{namespace}}"
         policy: "write"
       publish:
-        rule_write: "{{create_ns_consul_rule.stdout}}"
+        rule_write: "{{create_ns_consul_rule_write.stdout}}"
       on-success: "create_token_write"
     -
       name: "create_token_write"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -22,7 +22,7 @@
       ref: "kubernetes.create_secret"
       parameters:
         name: "consul-{{namespace}}-read"
-        value: "{{create_token_read}}"
+        value: "{{create_token_read.result}}"
         ns: "{{namespace}}"
       on-success: "create_ns_consul_rule_write"
     -
@@ -47,5 +47,5 @@
       ref: "kubernetes.create_secret"
       parameters:
         name: "consul-{{namespace}}-write"
-        value: "{{create_token_write}}"
+        value: "{{create_token_write.result}}"
         ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -32,7 +32,7 @@
         namespace: "{{namespace}}"
         policy: "write"
       publish:
-        rule_write: "{{create_ns_vault_rule.stdout}}"
+        rule_write: "{{create_ns_vault_rule_write.stdout}}"
       on-success: "create_token_write"
     -
       name: "create_token_write"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -21,13 +21,15 @@
       ref: "vault.create_token"
       parameters:
         policies: ["{{namespace}}-read"]
+      publish:
+        client_token: "{{create_token_read.stdout}}"
       on-success: "stash_read_token"
     -
       name: "stash_read_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-read"
-        value: "{{create_token_read.result}}"
+        value: "{{create_token_read.result.auth.client_token}}"
         ns: "{{namespace}}"
       on-success: "create_ns_vault_rule_write"
     -
@@ -51,11 +53,13 @@
       ref: "vault.create_token"
       parameters:
         policies: ["{{namespace}}-write"]
+      publish:
+        client_token: "{{create_token_write.stdout}}"
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-write"
-        value: "{{create_token_write.result}}"
+        value: "{{create_token_write.result.auth.client_token}}"
         ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -8,44 +8,54 @@
         policy: "read"
       publish:
         rule_read: "{{create_ns_vault_rule_read.stdout}}"
+      on-success: "create_policy_read"
+    -
+      name: "create_policy_read"
+      ref: "vault.set_policy"
+      parameters:
+        name: "{{namespace}}-read"
+        rules: "{{rule_read}}"
       on-success: "create_token_read"
     -
       name: "create_token_read"
       ref: "vault.create_token"
       parameters:
-        name: "{{namespace}}"
-        acl_type: "client"
-        rules: "{{rule_read}}"
-      on-success: "create_ns_vault_rule_write"
+        policies: ["{{namespace}}-read"]
+      on-success: "stash_read_token"
     -
       name: "stash_read_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-read"
-        value: "{{create_token_read}}"
+        value: "{{create_token_read.result}}"
         ns: "{{namespace}}"
       on-success: "create_ns_vault_rule_write"
     -
       name: "create_ns_vault_rule_write"
       ref: "bitesize.create_ns_vault_rule"
       parameters:
-        namespace: "{{namespace}}"
+        namespace: "{{namespace}}-write"
         policy: "write"
       publish:
         rule_write: "{{create_ns_vault_rule_write.stdout}}"
+      on-success: "create_policy_write"
+    -
+      name: "create_policy_write"
+      ref: "vault.set_policy"
+      parameters:
+        name: "{{namespace}}-write"
+        rules: "{{rule_write}}"
       on-success: "create_token_write"
     -
       name: "create_token_write"
       ref: "vault.create_token"
       parameters:
-        name: "{{namespace}}"
-        acl_type: "client"
-        rules: "{{rule_write}}"
+        policies: ["{{namespace}}-write"]
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-write"
-        value: "{{create_token_write}}"
+        value: "{{create_token_write.result}}"
         ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -18,6 +18,14 @@
         rules: "{{rule_read}}"
       on-success: "create_ns_vault_rule_write"
     -
+      name: "stash_read_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "vault-{{namespace}}-read"
+        value: "{{create_token_read}}"
+        ns: "{{namespace}}"
+      on-success: "create_ns_vault_rule_write"
+    -
       name: "create_ns_vault_rule_write"
       ref: "bitesize.create_ns_vault_rule"
       parameters:
@@ -33,3 +41,11 @@
         name: "{{namespace}}"
         acl_type: "client"
         rules: "{{rule_write}}"
+      on-success: "stash_write_token"
+    -
+      name: "stash_write_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "vault-{{namespace}}-write"
+        value: "{{create_token_write}}"
+        ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_ns.yaml
+++ b/packs/bitesize/actions/workflows/create_ns.yaml
@@ -6,6 +6,20 @@
             parameters:
                 ns: "{{ns}}"
                 suffix: "{{suffix}}"
+            on-success: "consul_tokens"
+            on-failure: "fail"
+        -
+            name: "consul_tokens"
+            ref: "bitesize.create_namespace_consul_tokens"
+            parameters:
+                namespace: "{{ns}}-{{suffix}}"
+            on-success: "vault_tokens"
+            on-failure: "fail"
+        -
+            name: "vault_tokens"
+            ref: "bitesize.create_namespace_vault_tokens"
+            parameters:
+                namespace: "{{ns}}-{{suffix}}"
             on-success: "label"
             on-failure: "fail"
         -

--- a/packs/kubernetes/actions/create_secret.py
+++ b/packs/kubernetes/actions/create_secret.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+import json
+import base64
+from st2actions.runners.pythonrunner import Action
+from lib import k8s
+from datetime import datetime
+
+secrettemplate = {
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "",
+        "namespace": ""
+    },
+    "data": {
+        "" : ""
+    }
+
+}
+
+class CreateSecret(Action):
+
+    def run(self, ns, name, value):
+
+        k8suser = self.config.get('user')
+        k8spass = self.config.get('password')
+        k8surl  = self.config.get('kubernetes_api_url')
+
+        b64value = base64.encodestring(value)
+        secretdata = {name: b64value}
+
+        mysecret = secrettemplate
+        mysecret['metadata']['name'] = name
+        mysecret['metadata']['namespace'] = ns
+        mysecret['data'] = secretdata
+
+        self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
+
+        resp = self.k8s.k8s[0].create_namespaced_secret(mysecret, ns).to_dict()
+        print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+
+    def _json_serial(self, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, datetime):
+            serial = obj.isoformat()
+            return serial
+        raise TypeError("Type not serializable")

--- a/packs/kubernetes/actions/create_secret.yaml
+++ b/packs/kubernetes/actions/create_secret.yaml
@@ -1,0 +1,23 @@
+---
+  name: "create_secret"
+  entry_point: "create_secret.py"
+  pack: "kubernetes"
+  description: "create a kubernetes secret in a namespace"
+  enabled: true
+  runner_type: run-python
+  parameters:
+    name:
+      type: "string"
+      required: true
+      description: "secret name"
+      position: 0
+    value:
+      type: "string"
+      required: true
+      description: "secret contents"
+      position: 1
+    ns:
+      type: "string"
+      description: "target namespace"
+      default: default
+      position: 0


### PR DESCRIPTION
## Pack bitesize/kuberneted

### Status 

Augments bitesize.create_ns

Adds tokens for consul/vault and stashes in kubernetes secrets in the appropriate namespace:
consul-{{ns}}-read
consul-{{ns}}-write
vault-{{ns}}-read 
vault-{{ns}}-write 

### Description

Intended for end-user app consumption by pods in the relevant namespaces.
Usage:

Use bitesize.create_ns to create a new namespace.

Observe that secrets containing the correct consul/vault tokens are created in the namespace:

```
# kubectl get secret vault-test-dev-read --namespace=test-dev -o yaml
apiVersion: v1
data:
  vault-test-dev-read: ZjA1NjZiMzgtNjA2YS04ODc0LTU3ODItYzliMjYyZTY4YjIw
kind: Secret
metadata:
  creationTimestamp: 2016-10-26T19:17:10Z
  name: vault-test-dev-read
  namespace: test-dev
  resourceVersion: "40864"
  selfLink: /api/v1/namespaces/test-dev/secrets/vault-test-dev-read
  uid: cb18ae5a-9bb0-11e6-8800-06501fc81933
type: Opaque
# echo "ZjA1NjZiMzgtNjA2YS04ODc0LTU3ODItYzliMjYyZTY4YjIw" | base64 -d
f0566b38-606a-8874-5782-c9b262e68b20
```