### PR TITLE
Bite 1142

### DIFF
--- a/packs/bitesize/actions/configure_consul_pack.meta.yaml
+++ b/packs/bitesize/actions/configure_consul_pack.meta.yaml
@@ -1,0 +1,7 @@
+---
+  name: "configure_consul_pack"
+  runner_type: "action-chain"
+  description: "Gets consul access token for stackstorm and configures consul/config.yaml"
+  enabled: true
+  entry_point: "workflows/configure_consul_pack.yaml"
+  pack: "bitesize"

--- a/packs/bitesize/actions/configure_vault_pack.meta.yaml
+++ b/packs/bitesize/actions/configure_vault_pack.meta.yaml
@@ -1,0 +1,7 @@
+---
+  name: "configure_vault_pack"
+  runner_type: "action-chain"
+  description: "Gets vault access token for stackstorm and configures vault/config.yaml"
+  enabled: true
+  entry_point: "workflows/configure_vault_pack.yaml"
+  pack: "bitesize"

--- a/packs/bitesize/actions/workflows/configure_consul_pack.yaml
+++ b/packs/bitesize/actions/workflows/configure_consul_pack.yaml
@@ -1,0 +1,21 @@
+---
+  chain:
+    -
+        name: "get_stackstorm_consul_token"
+        ref: "kubernetes.secret_read"
+        parameters:
+            name: "consul-stackstorm-mgmt"
+            ns: "kube-system"
+        on-success: "write_stackstorm_consul_token_to_config"
+        on-failure: "fail"
+    -
+        name: "write_stackstorm_consul_token_to_config"
+        ref: "core.local_sudo"
+        parameters:
+            cmd: "sed -i '/^token:/c\\token: {{get_stackstorm_consul_token.stdout}}' /opt/stackstorm/packs/consul/config.yaml"
+        on-failure: "fail"
+    -
+        name: "fail"
+        ref: "core.local"
+        parameters:
+            cmd: "echo fail"

--- a/packs/bitesize/actions/workflows/configure_vault_pack.yaml
+++ b/packs/bitesize/actions/workflows/configure_vault_pack.yaml
@@ -4,7 +4,7 @@
         name: "get_stackstorm_vault_token"
         ref: "kubernetes.secret_read"
         parameters:
-            name: "vault-stackstorm"
+            name: "vault-stackstorm-mgmt"
             ns: "kube-system"
         on-success: "write_stackstorm_vault_token_to_config"
         on-failure: "fail"

--- a/packs/bitesize/actions/workflows/configure_vault_pack.yaml
+++ b/packs/bitesize/actions/workflows/configure_vault_pack.yaml
@@ -1,0 +1,21 @@
+---
+  chain:
+    -
+        name: "get_stackstorm_vault_token"
+        ref: "kubernetes.secret_read"
+        parameters:
+            name: "vault-stackstorm"
+            ns: "kube-system"
+        on-success: "write_stackstorm_vault_token_to_config"
+        on-failure: "fail"
+    -
+        name: "write_stackstorm_vault_token_to_config"
+        ref: "core.local_sudo"
+        parameters:
+            cmd: "sed -i '/^token:/c\\token: {{get_stackstorm_vault_token.stdout}}' /opt/stackstorm/packs/vault/config.yaml"
+        on-failure: "fail"
+    -
+        name: "fail"
+        ref: "core.local"
+        parameters:
+            cmd: "echo fail"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -16,6 +16,14 @@
         name: "{{namespace}}"
         acl_type: "client"
         rules: "{{rule_read}}"
+      on-success: "stash_read_token"
+    -
+      name: "stash_read_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "consul-{{namespace}}-read"
+        value: "{{create_token_read}}"
+        ns: "{{namespace}}"
       on-success: "create_ns_consul_rule_write"
     -
       name: "create_ns_consul_rule_write"
@@ -33,3 +41,11 @@
         name: "{{namespace}}"
         acl_type: "client"
         rules: "{{rule_write}}"
+      on-success: "stash_write_token"
+    -
+      name: "stash_write_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "consul-{{namespace}}-write"
+        value: "{{create_token_write}}"
+        ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -32,7 +32,7 @@
         namespace: "{{namespace}}"
         policy: "write"
       publish:
-        rule_write: "{{create_ns_consul_rule.stdout}}"
+        rule_write: "{{create_ns_consul_rule_write.stdout}}"
       on-success: "create_token_write"
     -
       name: "create_token_write"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -19,7 +19,7 @@
       on-success: "stash_read_token"
     -
       name: "stash_read_token"
-      ref: "kubernetes."
+      ref: "kubernetes.secret_create"
       parameters:
         name: "consul-{{namespace}}-read"
         value: "{{create_token_read.result}}"
@@ -44,7 +44,7 @@
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
-      ref: "kubernetes."
+      ref: "kubernetes.secret_create"
       parameters:
         name: "consul-{{namespace}}-write"
         value: "{{create_token_write.result}}"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -1,51 +1,62 @@
 ---
-  chain:
-    -
-      name: "create_ns_consul_rule_read"
-      ref: "bitesize.create_ns_consul_rule"
-      parameters:
-        namespace: "{{namespace}}"
-        policy: "read"
-      publish:
-        rule_read: "{{create_ns_consul_rule_read.stdout}}"
-      on-success: "create_token_read"
-    -
-      name: "create_token_read"
-      ref: "consul.create_token"
-      parameters:
-        name: "{{namespace}}"
-        acl_type: "client"
-        rules: "{{rule_read}}"
-      on-success: "stash_read_token"
-    -
-      name: "stash_read_token"
-      ref: "kubernetes.secret_create"
-      parameters:
-        name: "consul-{{namespace}}-read"
-        value: "{{create_token_read.result}}"
-        ns: "{{namespace}}"
-      on-success: "create_ns_consul_rule_write"
-    -
-      name: "create_ns_consul_rule_write"
-      ref: "bitesize.create_ns_consul_rule"
-      parameters:
-        namespace: "{{namespace}}"
-        policy: "write"
-      publish:
-        rule_write: "{{create_ns_consul_rule_write.stdout}}"
-      on-success: "create_token_write"
-    -
-      name: "create_token_write"
-      ref: "consul.create_token"
-      parameters:
-        name: "{{namespace}}"
-        acl_type: "client"
-        rules: "{{rule_write}}"
-      on-success: "stash_write_token"
-    -
-      name: "stash_write_token"
-      ref: "kubernetes.secret_create"
-      parameters:
-        name: "consul-{{namespace}}-write"
-        value: "{{create_token_write.result}}"
-        ns: "{{namespace}}"
+    chain:
+        -
+            name: "create_ns_consul_rule_read"
+            ref: "bitesize.create_ns_consul_rule"
+            parameters:
+                namespace: "{{namespace}}"
+                policy: "read"
+            publish:
+                rule_read: "{{create_ns_consul_rule_read.stdout}}"
+            on-success: "create_token_read"
+            on-failure: "fail"
+        -
+            name: "create_token_read"
+            ref: "consul.create_token"
+            parameters:
+                name: "{{namespace}}"
+                acl_type: "client"
+                rules: "{{rule_read}}"
+            on-success: "stash_read_token"
+            on-failure: "fail"
+        -
+            name: "stash_read_token"
+            ref: "kubernetes.secret_create"
+            parameters:
+                name: "consul-{{namespace}}-read"
+                value: "{{create_token_read.result}}"
+                ns: "{{namespace}}"
+            on-success: "create_ns_consul_rule_write"
+            on-failure: "fail"
+        -
+            name: "create_ns_consul_rule_write"
+            ref: "bitesize.create_ns_consul_rule"
+            parameters:
+                namespace: "{{namespace}}"
+                policy: "write"
+            publish:
+                rule_write: "{{create_ns_consul_rule_write.stdout}}"
+            on-success: "create_token_write"
+            on-failure: "fail"
+        -
+            name: "create_token_write"
+            ref: "consul.create_token"
+            parameters:
+                name: "{{namespace}}"
+                acl_type: "client"
+                rules: "{{rule_write}}"
+            on-success: "stash_write_token"
+            on-failure: "fail"
+        -
+            name: "stash_write_token"
+            ref: "kubernetes.secret_create"
+            parameters:
+                name: "consul-{{namespace}}-write"
+                value: "{{create_token_write.result}}"
+                ns: "{{namespace}}"
+            on-failure: "fail"
+        -
+            name: "fail"
+            ref: "core.local"
+            parameters:
+                cmd: "echo fail"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -19,7 +19,7 @@
       on-success: "stash_read_token"
     -
       name: "stash_read_token"
-      ref: "kubernetes.create_secret"
+      ref: "kubernetes."
       parameters:
         name: "consul-{{namespace}}-read"
         value: "{{create_token_read.result}}"
@@ -44,7 +44,7 @@
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
-      ref: "kubernetes.create_secret"
+      ref: "kubernetes."
       parameters:
         name: "consul-{{namespace}}-write"
         value: "{{create_token_write.result}}"

--- a/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_consul_tokens.yaml
@@ -22,7 +22,7 @@
       ref: "kubernetes.create_secret"
       parameters:
         name: "consul-{{namespace}}-read"
-        value: "{{create_token_read}}"
+        value: "{{create_token_read.result}}"
         ns: "{{namespace}}"
       on-success: "create_ns_consul_rule_write"
     -
@@ -47,5 +47,5 @@
       ref: "kubernetes.create_secret"
       parameters:
         name: "consul-{{namespace}}-write"
-        value: "{{create_token_write}}"
+        value: "{{create_token_write.result}}"
         ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -26,7 +26,7 @@
       on-success: "stash_read_token"
     -
       name: "stash_read_token"
-      ref: "kubernetes.create_secret"
+      ref: "kubernetes."
       parameters:
         name: "vault-{{namespace}}-read"
         value: "{{create_token_read.result.auth.client_token}}"
@@ -58,7 +58,7 @@
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
-      ref: "kubernetes.create_secret"
+      ref: "kubernetes."
       parameters:
         name: "vault-{{namespace}}-write"
         value: "{{create_token_write.result.auth.client_token}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -32,7 +32,7 @@
         namespace: "{{namespace}}"
         policy: "write"
       publish:
-        rule_write: "{{create_ns_vault_rule.stdout}}"
+        rule_write: "{{create_ns_vault_rule_write.stdout}}"
       on-success: "create_token_write"
     -
       name: "create_token_write"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -1,65 +1,78 @@
 ---
   chain:
-    -
-      name: "create_ns_vault_rule_read"
-      ref: "bitesize.create_ns_vault_rule"
-      parameters:
-        namespace: "{{namespace}}"
-        policy: "read"
-      publish:
-        rule_read: "{{create_ns_vault_rule_read.stdout}}"
-      on-success: "create_policy_read"
-    -
-      name: "create_policy_read"
-      ref: "vault.set_policy"
-      parameters:
-        name: "{{namespace}}-read"
-        rules: "{{rule_read}}"
-      on-success: "create_token_read"
-    -
-      name: "create_token_read"
-      ref: "vault.create_token"
-      parameters:
-        policies: ["{{namespace}}-read"]
-      publish:
-        client_token: "{{create_token_read.stdout}}"
-      on-success: "stash_read_token"
-    -
-      name: "stash_read_token"
-      ref: "kubernetes.secret_create"
-      parameters:
-        name: "vault-{{namespace}}-read"
-        value: "{{create_token_read.result.auth.client_token}}"
-        ns: "{{namespace}}"
-      on-success: "create_ns_vault_rule_write"
-    -
-      name: "create_ns_vault_rule_write"
-      ref: "bitesize.create_ns_vault_rule"
-      parameters:
-        namespace: "{{namespace}}-write"
-        policy: "write"
-      publish:
-        rule_write: "{{create_ns_vault_rule_write.stdout}}"
-      on-success: "create_policy_write"
-    -
-      name: "create_policy_write"
-      ref: "vault.set_policy"
-      parameters:
-        name: "{{namespace}}-write"
-        rules: "{{rule_write}}"
-      on-success: "create_token_write"
-    -
-      name: "create_token_write"
-      ref: "vault.create_token"
-      parameters:
-        policies: ["{{namespace}}-write"]
-      publish:
-        client_token: "{{create_token_write.stdout}}"
-      on-success: "stash_write_token"
-    -
-      name: "stash_write_token"
-      ref: "kubernetes.secret_create"
-      parameters:
-        name: "vault-{{namespace}}-write"
-        value: "{{create_token_write.result.auth.client_token}}"
-        ns: "{{namespace}}"
+        -
+            name: "create_ns_vault_rule_read"
+            ref: "bitesize.create_ns_vault_rule"
+            parameters:
+                namespace: "{{namespace}}"
+                policy: "read"
+            publish:
+                rule_read: "{{create_ns_vault_rule_read.stdout}}"
+            on-success: "create_policy_read"
+            on-failure: "fail"
+        -
+            name: "create_policy_read"
+            ref: "vault.set_policy"
+            parameters:
+                name: "{{namespace}}-read"
+                rules: "{{rule_read}}"
+            on-success: "create_token_read"
+            on-failure: "fail"
+        -
+            name: "create_token_read"
+            ref: "vault.create_token"
+            parameters:
+                policies: ["{{namespace}}-read"]
+            publish:
+                client_token: "{{create_token_read.stdout}}"
+            on-success: "stash_read_token"
+            on-failure: "fail"
+        -
+            name: "stash_read_token"
+            ref: "kubernetes.secret_create"
+            parameters:
+                name: "vault-{{namespace}}-read"
+                value: "{{create_token_read.result.auth.client_token}}"
+                ns: "{{namespace}}"
+            on-success: "create_ns_vault_rule_write"
+            on-failure: "fail"
+        -
+            name: "create_ns_vault_rule_write"
+            ref: "bitesize.create_ns_vault_rule"
+            parameters:
+                namespace: "{{namespace}}-write"
+                policy: "write"
+            publish:
+              rule_write: "{{create_ns_vault_rule_write.stdout}}"
+            on-success: "create_policy_write"
+            on-failure: "fail"
+        -
+            name: "create_policy_write"
+            ref: "vault.set_policy"
+            parameters:
+                name: "{{namespace}}-write"
+                rules: "{{rule_write}}"
+            on-success: "create_token_write"
+            on-failure: "fail"
+        -
+            name: "create_token_write"
+            ref: "vault.create_token"
+            parameters:
+                policies: ["{{namespace}}-write"]
+            publish:
+                client_token: "{{create_token_write.stdout}}"
+            on-success: "stash_write_token"
+            on-failure: "fail"
+        -
+            name: "stash_write_token"
+            ref: "kubernetes.secret_create"
+            parameters:
+                name: "vault-{{namespace}}-write"
+                value: "{{create_token_write.result.auth.client_token}}"
+                ns: "{{namespace}}"
+            on-failure: "fail"
+        -
+            name: "fail"
+            ref: "core.local"
+            parameters:
+                cmd: "echo fail"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -21,13 +21,15 @@
       ref: "vault.create_token"
       parameters:
         policies: ["{{namespace}}-read"]
+      publish:
+        client_token: "{{create_token_read.stdout}}"
       on-success: "stash_read_token"
     -
       name: "stash_read_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-read"
-        value: "{{create_token_read.result}}"
+        value: "{{create_token_read.result.auth.client_token}}"
         ns: "{{namespace}}"
       on-success: "create_ns_vault_rule_write"
     -
@@ -51,11 +53,13 @@
       ref: "vault.create_token"
       parameters:
         policies: ["{{namespace}}-write"]
+      publish:
+        client_token: "{{create_token_write.stdout}}"
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-write"
-        value: "{{create_token_write.result}}"
+        value: "{{create_token_write.result.auth.client_token}}"
         ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -8,44 +8,54 @@
         policy: "read"
       publish:
         rule_read: "{{create_ns_vault_rule_read.stdout}}"
+      on-success: "create_policy_read"
+    -
+      name: "create_policy_read"
+      ref: "vault.set_policy"
+      parameters:
+        name: "{{namespace}}-read"
+        rules: "{{rule_read}}"
       on-success: "create_token_read"
     -
       name: "create_token_read"
       ref: "vault.create_token"
       parameters:
-        name: "{{namespace}}"
-        acl_type: "client"
-        rules: "{{rule_read}}"
-      on-success: "create_ns_vault_rule_write"
+        policies: ["{{namespace}}-read"]
+      on-success: "stash_read_token"
     -
       name: "stash_read_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-read"
-        value: "{{create_token_read}}"
+        value: "{{create_token_read.result}}"
         ns: "{{namespace}}"
       on-success: "create_ns_vault_rule_write"
     -
       name: "create_ns_vault_rule_write"
       ref: "bitesize.create_ns_vault_rule"
       parameters:
-        namespace: "{{namespace}}"
+        namespace: "{{namespace}}-write"
         policy: "write"
       publish:
         rule_write: "{{create_ns_vault_rule_write.stdout}}"
+      on-success: "create_policy_write"
+    -
+      name: "create_policy_write"
+      ref: "vault.set_policy"
+      parameters:
+        name: "{{namespace}}-write"
+        rules: "{{rule_write}}"
       on-success: "create_token_write"
     -
       name: "create_token_write"
       ref: "vault.create_token"
       parameters:
-        name: "{{namespace}}"
-        acl_type: "client"
-        rules: "{{rule_write}}"
+        policies: ["{{namespace}}-write"]
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
       ref: "kubernetes.create_secret"
       parameters:
         name: "vault-{{namespace}}-write"
-        value: "{{create_token_write}}"
+        value: "{{create_token_write.result}}"
         ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -26,7 +26,7 @@
       on-success: "stash_read_token"
     -
       name: "stash_read_token"
-      ref: "kubernetes."
+      ref: "kubernetes.secret_create"
       parameters:
         name: "vault-{{namespace}}-read"
         value: "{{create_token_read.result.auth.client_token}}"
@@ -58,7 +58,7 @@
       on-success: "stash_write_token"
     -
       name: "stash_write_token"
-      ref: "kubernetes."
+      ref: "kubernetes.secret_create"
       parameters:
         name: "vault-{{namespace}}-write"
         value: "{{create_token_write.result.auth.client_token}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -18,6 +18,14 @@
         rules: "{{rule_read}}"
       on-success: "create_ns_vault_rule_write"
     -
+      name: "stash_read_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "vault-{{namespace}}-read"
+        value: "{{create_token_read}}"
+        ns: "{{namespace}}"
+      on-success: "create_ns_vault_rule_write"
+    -
       name: "create_ns_vault_rule_write"
       ref: "bitesize.create_ns_vault_rule"
       parameters:
@@ -33,3 +41,11 @@
         name: "{{namespace}}"
         acl_type: "client"
         rules: "{{rule_write}}"
+      on-success: "stash_write_token"
+    -
+      name: "stash_write_token"
+      ref: "kubernetes.create_secret"
+      parameters:
+        name: "vault-{{namespace}}-write"
+        value: "{{create_token_write}}"
+        ns: "{{namespace}}"

--- a/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
+++ b/packs/bitesize/actions/workflows/create_namespace_vault_tokens.yaml
@@ -40,7 +40,7 @@
             name: "create_ns_vault_rule_write"
             ref: "bitesize.create_ns_vault_rule"
             parameters:
-                namespace: "{{namespace}}-write"
+                namespace: "{{namespace}}"
                 policy: "write"
             publish:
               rule_write: "{{create_ns_vault_rule_write.stdout}}"

--- a/packs/bitesize/actions/workflows/create_ns.yaml
+++ b/packs/bitesize/actions/workflows/create_ns.yaml
@@ -6,6 +6,20 @@
             parameters:
                 ns: "{{ns}}"
                 suffix: "{{suffix}}"
+            on-success: "consul_tokens"
+            on-failure: "fail"
+        -
+            name: "consul_tokens"
+            ref: "bitesize.create_namespace_consul_tokens"
+            parameters:
+                namespace: "{{ns}}-{{suffix}}"
+            on-success: "vault_tokens"
+            on-failure: "fail"
+        -
+            name: "vault_tokens"
+            ref: "bitesize.create_namespace_vault_tokens"
+            parameters:
+                namespace: "{{ns}}-{{suffix}}"
             on-success: "label"
             on-failure: "fail"
         -

--- a/packs/kubernetes/actions/create_secret.py
+++ b/packs/kubernetes/actions/create_secret.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+import json
+import base64
+from st2actions.runners.pythonrunner import Action
+from lib import k8s
+from datetime import datetime
+
+secrettemplate = {
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "",
+        "namespace": ""
+    },
+    "data": {
+        "" : ""
+    }
+
+}
+
+class CreateSecret(Action):
+
+    def run(self, ns, name, value):
+
+        k8suser = self.config.get('user')
+        k8spass = self.config.get('password')
+        k8surl  = self.config.get('kubernetes_api_url')
+
+        b64value = base64.encodestring(value)
+        secretdata = {name: b64value}
+
+        mysecret = secrettemplate
+        mysecret['metadata']['name'] = name
+        mysecret['metadata']['namespace'] = ns
+        mysecret['data'] = secretdata
+
+        self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
+
+        resp = self.k8s.k8s[0].create_namespaced_secret(mysecret, ns).to_dict()
+        print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+
+    def _json_serial(self, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, datetime):
+            serial = obj.isoformat()
+            return serial
+        raise TypeError("Type not serializable")

--- a/packs/kubernetes/actions/create_secret.yaml
+++ b/packs/kubernetes/actions/create_secret.yaml
@@ -1,0 +1,23 @@
+---
+  name: "create_secret"
+  entry_point: "create_secret.py"
+  pack: "kubernetes"
+  description: "create a kubernetes secret in a namespace"
+  enabled: true
+  runner_type: run-python
+  parameters:
+    name:
+      type: "string"
+      required: true
+      description: "secret name"
+      position: 0
+    value:
+      type: "string"
+      required: true
+      description: "secret contents"
+      position: 1
+    ns:
+      type: "string"
+      description: "target namespace"
+      default: default
+      position: 0

--- a/packs/kubernetes/actions/secret_create.py
+++ b/packs/kubernetes/actions/secret_create.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+import json
+import base64
+from st2actions.runners.pythonrunner import Action
+from lib import k8s
+from datetime import datetime
+
+secrettemplate = {
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "",
+        "namespace": ""
+    },
+    "data": {
+        "" : ""
+    }
+
+}
+
+class SecretCreate(Action):
+
+    def run(self, ns, name, value):
+
+        k8suser = self.config.get('user')
+        k8spass = self.config.get('password')
+        k8surl  = self.config.get('kubernetes_api_url')
+
+        b64value = base64.encodestring(value)
+        secretdata = {name: b64value}
+
+        mysecret = secrettemplate
+        mysecret['metadata']['name'] = name
+        mysecret['metadata']['namespace'] = ns
+        mysecret['data'] = secretdata
+
+        self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
+
+        resp = self.k8s.k8s[0].create_namespaced_secret(mysecret, ns).to_dict()
+        print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+
+    def _json_serial(self, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, datetime):
+            serial = obj.isoformat()
+            return serial
+        raise TypeError("Type not serializable")

--- a/packs/kubernetes/actions/secret_create.py
+++ b/packs/kubernetes/actions/secret_create.py
@@ -37,7 +37,7 @@ class SecretCreate(Action):
         self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
 
         resp = self.k8s.k8s[0].create_namespaced_secret(mysecret, ns).to_dict()
-        print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+        #print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
 
     def _json_serial(self, obj):
         """JSON serializer for objects not serializable by default json code"""

--- a/packs/kubernetes/actions/secret_create.yaml
+++ b/packs/kubernetes/actions/secret_create.yaml
@@ -1,6 +1,6 @@
 ---
-  name: "create_secret"
-  entry_point: "create_secret.py"
+  name: "secret_create"
+  entry_point: "secret_create.py"
   pack: "kubernetes"
   description: "create a kubernetes secret in a namespace"
   enabled: true

--- a/packs/kubernetes/actions/secret_delete.py
+++ b/packs/kubernetes/actions/secret_delete.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+import json
+import base64
+from st2actions.runners.pythonrunner import Action
+from lib import k8s
+from datetime import datetime
+
+deleteoptions = {}
+
+class SecretDelete(Action):
+
+    def run(self, ns, name):
+
+        k8suser = self.config.get('user')
+        k8spass = self.config.get('password')
+        k8surl  = self.config.get('kubernetes_api_url')
+
+        self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
+
+        resp = self.k8s.k8s[0].delete_namespaced_secret(deleteoptions, ns, name).to_dict()
+        print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+
+    def _json_serial(self, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, datetime):
+            serial = obj.isoformat()
+            return serial
+        raise TypeError("Type not serializable")

--- a/packs/kubernetes/actions/secret_delete.yaml
+++ b/packs/kubernetes/actions/secret_delete.yaml
@@ -1,0 +1,18 @@
+---
+  name: "secret_delete"
+  entry_point: "secret_delete.py"
+  pack: "kubernetes"
+  description: "delete a kubernetes secret in a namespace"
+  enabled: true
+  runner_type: run-python
+  parameters:
+    name:
+      type: "string"
+      required: true
+      description: "secret name"
+      position: 0
+    ns:
+      type: "string"
+      description: "target namespace"
+      default: default
+      position: 0

--- a/packs/kubernetes/actions/secret_read.py
+++ b/packs/kubernetes/actions/secret_read.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import json
+import base64
 from st2actions.runners.pythonrunner import Action
 from lib import k8s
 from datetime import datetime
@@ -15,7 +16,11 @@ class SecretRead(Action):
         self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
 
         resp = self.k8s.k8s[0].read_namespaced_secret(ns, name).to_dict()
-        print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+        datastr = json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+        data = json.loads(datastr)
+        secret = data['data']
+
+        print base64.decodestring(secret[name])
 
     def _json_serial(self, obj):
         """JSON serializer for objects not serializable by default json code"""

--- a/packs/kubernetes/actions/secret_read.py
+++ b/packs/kubernetes/actions/secret_read.py
@@ -1,42 +1,20 @@
 #!/usr/bin/python
 import json
-import base64
 from st2actions.runners.pythonrunner import Action
 from lib import k8s
 from datetime import datetime
 
-secrettemplate = {
-    "kind": "Secret",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "",
-        "namespace": ""
-    },
-    "data": {
-        "" : ""
-    }
+class SecretRead(Action):
 
-}
-
-class CreateSecret(Action):
-
-    def run(self, ns, name, value):
+    def run(self, ns, name):
 
         k8suser = self.config.get('user')
         k8spass = self.config.get('password')
         k8surl  = self.config.get('kubernetes_api_url')
 
-        b64value = base64.encodestring(value)
-        secretdata = {name: b64value}
-
-        mysecret = secrettemplate
-        mysecret['metadata']['name'] = name
-        mysecret['metadata']['namespace'] = ns
-        mysecret['data'] = secretdata
-
         self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
 
-        resp = self.k8s.k8s[0].create_namespaced_secret(mysecret, ns).to_dict()
+        resp = self.k8s.k8s[0].read_namespaced_secret(ns, name).to_dict()
         print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
 
     def _json_serial(self, obj):

--- a/packs/kubernetes/actions/secret_read.yaml
+++ b/packs/kubernetes/actions/secret_read.yaml
@@ -1,0 +1,18 @@
+---
+  name: "secret_read"
+  entry_point: "secret_read.py"
+  pack: "kubernetes"
+  description: "read a kubernetes secret in a namespace"
+  enabled: true
+  runner_type: run-python
+  parameters:
+    name:
+      type: "string"
+      required: true
+      description: "secret name"
+      position: 0
+    ns:
+      type: "string"
+      description: "target namespace"
+      default: default
+      position: 0

--- a/packs/kubernetes/actions/secret_replace.py
+++ b/packs/kubernetes/actions/secret_replace.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+import json
+import base64
+from st2actions.runners.pythonrunner import Action
+from lib import k8s
+from datetime import datetime
+
+secrettemplate = {
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "",
+        "namespace": ""
+    },
+    "data": {
+        "" : ""
+    }
+
+}
+
+class SecretReplace(Action):
+
+    def run(self, ns, name, value):
+
+        k8suser = self.config.get('user')
+        k8spass = self.config.get('password')
+        k8surl  = self.config.get('kubernetes_api_url')
+
+        b64value = base64.encodestring(value)
+        secretdata = {name: b64value}
+
+        mysecret = secrettemplate
+        mysecret['metadata']['name'] = name
+        mysecret['metadata']['namespace'] = ns
+        mysecret['data'] = secretdata
+
+        self.k8s = k8s.K8sClient(k8surl, k8suser, k8spass)
+
+        resp = self.k8s.k8s[0].replace_namespaced_secret(mysecret, ns, name).to_dict()
+        #print json.dumps(resp, sort_keys=True, indent=2, default=self._json_serial)
+
+    def _json_serial(self, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, datetime):
+            serial = obj.isoformat()
+            return serial
+        raise TypeError("Type not serializable")

--- a/packs/kubernetes/actions/secret_replace.yaml
+++ b/packs/kubernetes/actions/secret_replace.yaml
@@ -1,0 +1,23 @@
+---
+  name: "secret_replace"
+  entry_point: "secret_replace.py"
+  pack: "kubernetes"
+  description: "replaces a kubernetes secret in a namespace"
+  enabled: true
+  runner_type: run-python
+  parameters:
+    name:
+      type: "string"
+      required: true
+      description: "secret name"
+      position: 0
+    value:
+      type: "string"
+      required: true
+      description: "secret contents"
+      position: 1
+    ns:
+      type: "string"
+      description: "target namespace"
+      default: default
+      position: 0

--- a/packs/kubernetes/rules/consul_secret_create.yaml
+++ b/packs/kubernetes/rules/consul_secret_create.yaml
@@ -1,0 +1,26 @@
+---
+name: "consul_secret_create"
+pack: "kubernetes"
+description: "Check for new secrets"
+enabled: true
+
+trigger:
+  type: "kubernetes.secret"
+  parameters: {}
+
+criteria:
+  trigger.resource_type:
+    type: "contains"
+    pattern: "ADDED"
+  trigger.object_kind:
+    type: "equals"
+    pattern: "Secret"
+  trigger.name:
+    type: "equals"
+    pattern: "consul-stackstorm-mgmt"
+  trigger.namespace:
+    type: "equals"
+    pattern: "kube-system"
+
+action:
+  ref: "bitesize.configure_consul_pack"

--- a/packs/kubernetes/rules/vault_secret_create.yaml
+++ b/packs/kubernetes/rules/vault_secret_create.yaml
@@ -1,0 +1,26 @@
+---
+name: "vault_secret_create"
+pack: "kubernetes"
+description: "Check for new secrets"
+enabled: true
+
+trigger:
+  type: "kubernetes.secret"
+  parameters: {}
+
+criteria:
+  trigger.resource_type:
+    type: "contains"
+    pattern: "ADDED"
+  trigger.object_kind:
+    type: "equals"
+    pattern: "Secret"
+  trigger.name:
+    type: "equals"
+    pattern: "vault-stackstorm-mgmt"
+  trigger.namespace:
+    type: "equals"
+    pattern: "kube-system"
+
+action:
+  ref: "bitesize.configure_vault_pack"

--- a/packs/kubernetes/sensors/kube_system_secret.py
+++ b/packs/kubernetes/sensors/kube_system_secret.py
@@ -9,7 +9,7 @@ from st2reactor.sensor.base import Sensor
 
 class KubeSystemSecret(Sensor):
     def __init__(self, sensor_service, config=None):
-        super(Secret, self).__init__(sensor_service=sensor_service, config=config)
+        super(KubeSystemSecret, self).__init__(sensor_service=sensor_service, config=config)
         self._log = self._sensor_service.get_logger(__name__)
         self.TRIGGER_REF = 'kubernetes.secret'
         self.client = None

--- a/packs/kubernetes/sensors/kube_system_secret.py
+++ b/packs/kubernetes/sensors/kube_system_secret.py
@@ -1,0 +1,106 @@
+import ast
+import json
+import sys
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from st2reactor.sensor.base import Sensor
+
+class KubeSystemSecret(Sensor):
+    def __init__(self, sensor_service, config=None):
+        super(Secret, self).__init__(sensor_service=sensor_service, config=config)
+        self._log = self._sensor_service.get_logger(__name__)
+        self.TRIGGER_REF = 'kubernetes.secret'
+        self.client = None
+
+    def setup(self):
+        try:
+            extension = "/api/v1/watch/namespaces/kube-system/secrets"
+            KUBERNETES_API_URL = self._config['kubernetes_api_url'] + extension
+            user = self._config['user']
+            password = self._config['password']
+            verify = self._config['verify']
+        except KeyError:
+            self._log.exception('Configuration file does not contain required fields.')
+            raise
+        self._log.debug('Connecting to Kubernetes endpoint %s via api_client.' %
+                        KUBERNETES_API_URL)
+        self.client = requests.get(KUBERNETES_API_URL, auth=HTTPBasicAuth(user, password),
+                                   verify=verify, stream=True)
+
+    def run(self):
+        self._log.debug('Watch Kubernetes for new secrets')
+        r = self.client
+        lines = r.iter_lines()
+        # Save the first line for later or just skip it
+        # first_line = next(lines)
+
+        for line in lines:
+            try:
+                trigger_payload = self._get_trigger_payload_from_line(line)
+            except:
+                msg = ('Failed generating trigger payload from line %s. Aborting sensor!!!' %
+                    line)
+                self._log.exception(msg)
+                sys.exit(1)
+            else:
+                if trigger_payload == 0:
+                    pass
+                else:
+                    self._log.debug('Triggering Dispatch Now')
+                    self._sensor_service.dispatch(trigger=self.TRIGGER_REF, payload=trigger_payload)
+
+    def _get_trigger_payload_from_line(self, line):
+        k8s_object = self._fix_utf8_enconding_and_eval(line)
+        self._log.debug('Incoming k8s object (from API response): %s', k8s_object)
+        payload = self._k8s_object_to_st2_trigger(k8s_object)
+        return payload
+
+    def _fix_utf8_enconding_and_eval(self, line):
+        # need to perform a json dump due to uft8 error prior to performing a json.load
+        io = json.dumps(line)
+        n = json.loads(io)
+        line = ast.literal_eval(n)
+        return line
+
+    def _k8s_object_to_st2_trigger(self, k8s_object):
+        # Define some variables
+        try:
+            resource_type = k8s_object['type']
+            object_kind = k8s_object['object']['kind']
+            name = k8s_object['object']['metadata']['name']
+            namespace = k8s_object['object']['metadata']['namespace']
+        except KeyError:
+            msg = 'One of "type", "kind", "name", "namespace" ' + \
+                  'do not exist in the object. Incoming object=%s' % k8s_object
+            self._log.exception(msg)
+            #raise
+            return 0
+        else:
+            payload = self._build_a_trigger(resource_type=resource_type, object_kind=object_kind, name=name, namespace=namespace)
+            self._log.debug('Trigger payload: %s.' % payload)
+            self._log.info('Trigger payload: %s.' % payload)
+            return payload
+
+    def _build_a_trigger(self, resource_type, object_kind, name, namespace):
+        payload = {
+            'resource_type': resource_type,
+            'object_kind': object_kind,
+            'name': name,
+            'namespace': namespace
+        }
+
+        return payload
+
+    def cleanup(self):
+        pass
+
+    def add_trigger(self, trigger):
+        pass
+
+    def update_trigger(self, trigger):
+        pass
+
+    def remove_trigger(self, trigger):
+        pass

--- a/packs/kubernetes/sensors/kube_system_secret.yaml
+++ b/packs/kubernetes/sensors/kube_system_secret.yaml
@@ -1,0 +1,19 @@
+---
+  class_name: "KubeSystemSecret"
+  entry_point: "kube_system_secret.py"
+  description: "Sensor which watches Kubernetes API for new secrets in kube-system."
+  trigger_types:
+    -
+      name: "secret"
+      description: "Trigger which contains metadata for secret dispatch."
+      payload_schema:
+        type: "object"
+        properties:
+          resource_type:
+            type: "obj"
+          name:
+            type: "obj"
+          namespace:
+            type: "obj"
+          object_kind:
+            type: "obj"

--- a/packs/vault/requirements.txt
+++ b/packs/vault/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/ianunruh/hvac.git#hvac
+git+git://github.com/ianunruh/hvac.git@v0.2.16


### PR DESCRIPTION
Adds functionality for consul and vault packs to self-configure on top of namespace token creation functionality added in bite-1116. 

Validation:

In terraform.tfvars:
```
st2_branch="bite-1142"
ansible_branch="bite-1142"
```
Build cluster.

Run bitesize.create_ns action to create a namespace of your choice:

https://stackstorm.mdev.prsn-dev.io/#/actions/bitesize.create_ns/general

Note that read and write tokens are created for both consul and vault and stashed in kubernetes secrets in your new namesapce:

```
kubectl get secrets --namespace=<your_ns>
```

See bitesize/bite-1142 PR.