### PR TITLE
Make namespace mandatory in sub-workflows too

### DIFF
--- a/packs/bitesize/actions/create_namespace_consul_tokens.meta.yaml
+++ b/packs/bitesize/actions/create_namespace_consul_tokens.meta.yaml
@@ -9,3 +9,4 @@
     namespace:
       type: "string"
       description: "namespace"
+      required: true

--- a/packs/bitesize/actions/create_namespace_vault_tokens.meta.yaml
+++ b/packs/bitesize/actions/create_namespace_vault_tokens.meta.yaml
@@ -9,3 +9,4 @@
     namespace:
       type: "string"
       description: "namespace"
+      required: true


### PR DESCRIPTION

Validate:

It should no longer be possible to run the following workflows without specifying a Namespace:

bitesize.create_namespace_consul_tokens 
bitesize.create_namespace_vault_tokens 
