### PR TITLE
Bite-1351: Fixes deployment migration when there is/isn't a liveness probe

### DIFF
--- a/packs/kubernetes/actions/migrate_cluster.py
+++ b/packs/kubernetes/actions/migrate_cluster.py
@@ -208,7 +208,7 @@ class K8sMigrateAction(Action):
                                     'spec']['restartPolicy']
                             if "containers" in item['spec']['template']['spec']:
                                 for cont in item['spec']['template']['spec']['containers']:
-                                    if "livenessProbe" in cont:
+                                    if cont['livenessProbe'] is not None:
                                         if "_exec" in cont['livenessProbe']:
                                             cont['livenessProbe']['exec'] = cont['livenessProbe'].pop('_exec')
                     if "clusterIP" in item['spec']:


### PR DESCRIPTION
Updates to make sure if a deployment doesn't have a liveness probe, it won't fail on NoneType

Companion Bitesize PR: https://github.com/pearsontechnology/bitesize/pull/797