### PR TITLE
[cops-530]: Stackstorm allow only dev, qa, nft, stg, and prd in action create_ns

### DIFF
--- a/packs/bitesize/actions/create_ns.meta.yaml
+++ b/packs/bitesize/actions/create_ns.meta.yaml
@@ -15,7 +15,8 @@
       type: "string"
       enum:
         - dev
-        - tst
+        - qa
+        - nft
         - stg
         - prd
       default: dev


### PR DESCRIPTION
## Pack (bitesize)

### Status 

Changed environment name suffix from enum list
- removed "tst"
- added "qa" and "nft"

### Description

Change bitesize.create_ns to allow any permitted suffix defined in below doc
http://docs.prsn.io/docs/standards/environmentnamingstandards

