### PR TITLE
Removing sample-app/test-app from logic as they are not pre-exisintin…

### DIFF
--- a/packs/kubernetes/actions/migrate_cluster.py
+++ b/packs/kubernetes/actions/migrate_cluster.py
@@ -91,7 +91,7 @@ class K8sMigrateAction(Action):
             print "name: " + name
             if name in ['default', 'test-runner']:
                 continue
-            if name in ['kube-system', 'test-app', 'sample-app']:
+            if name in ['kube-system']:
                 get_and_post("secret", ns=name)
             else:
                 get_and_post("ns", ns=name)


### PR DESCRIPTION
Removes test-app/sample-app NS from migration check as it assumes they are pre-existing. Test-app and Sample-app are not deployed on paas standup and only existing in production.

Companion PR: 