### PR TITLE
BITE-1402: Fix Travis Builds

### DIFF
--- a/packs/bitesize/actions/layer_terraform_config.py
+++ b/packs/bitesize/actions/layer_terraform_config.py
@@ -23,14 +23,17 @@ class LayerTerraformConfig(Action):
     gddata = {}
     rddata = {}
 
-    if rspecifics['data'] is not None:
-      rspdata = self._getkv(rspecifics['data'])
+    if rspecifics is not None:
+      if rspecifics['data'] is not None:
+        rspdata = self._getkv(rspecifics['data'])
 
-    if rdefaults['data'] is not None:
-      rddata = self._getkv(rdefaults['data'])
+    if rdefaults is not None:
+      if rdefaults['data'] is not None:
+        rddata = self._getkv(rdefaults['data'])
 
-    if gdefaults['data'] is not None:
-      gddata = self._getkv(gdefaults['data'])
+    if gdefaults is not None:
+      if gdefaults['data'] is not None:
+        gddata = self._getkv(gdefaults['data'])
 
     print json.dumps(gddata, sort_keys=True, indent=2)
     print json.dumps(rddata, sort_keys=True, indent=2)

--- a/packs/bitesize/actions/layer_terraform_config.yaml
+++ b/packs/bitesize/actions/layer_terraform_config.yaml
@@ -11,3 +11,4 @@ parameters:
     type: object
   rspecifics:
     type: object
+    required: false 

--- a/packs/bitesize/actions/workflows/terraform_config.yaml
+++ b/packs/bitesize/actions/workflows/terraform_config.yaml
@@ -48,8 +48,19 @@ bitesize.terraform_config:
         recurse: True
       publish:
         rspecifics: <% task(get_region_specifics).result.result %>
-      on-complete:
+      on-success:
         - layer_config
+      on-error:
+        - layer_config_no_specifics
+    layer_config_no_specifics:
+      action: bitesize.layer_terraform_config
+      input:
+        gdefaults: <% dict(data=>$.gdefaults) %>
+        rdefaults: <% dict(data=>$.rdefaults) %>
+      publish:
+        config: <% task(layer_config_no_specifics).result.result %>
+      on-success:
+        - write_terraform_config
     layer_config:
       action: bitesize.layer_terraform_config
       input:


### PR DESCRIPTION
Handles the case where region specific deployment data is not in consul and ensures the tfvars data is still produced.

More information is in the ticket description: https://one-jira.pearson.com/browse/BITE-1402

https://travis-ci.com/pearsontechnology/bitesize/builds/43176682#L382 lines (382-385) show that the deploy was successful meaning tfvars was generated